### PR TITLE
Alright, I've made a fix to resolve the 404 error you were seeing whe…

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -150,10 +150,9 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToSignup, onSucces
         onSuccess?.();
         
         // Redirect to dashboard after a short delay
-        setTimeout(() => {
-          debugLog('Redirecting to dashboard');
-          window.location.href = '/dashboard';
-        }, 1000);
+        debugLog('Redirecting to dashboard using pushState');
+        window.history.pushState(null, '', '/dashboard');
+        window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
         
       } else {
         debugLog('Unexpected: no user data returned', data);


### PR DESCRIPTION
…n redirecting to `/dashboard` after an email sign-in.

Previously, after a successful email sign-in, the application would use `window.location.href = '/dashboard'` to navigate. This caused a full page reload, which meant the browser made a GET request to the server for the `/dashboard` path. If the server wasn't set up to serve `index.html` for all single-page application routes, you'd get a 404 error.

I've changed how the redirection works in `LoginForm.tsx` to use client-side navigation instead:
- I replaced `setTimeout(() => { window.location.href = '/dashboard'; }, 1000);`
- With `window.history.pushState(null, '', '/dashboard');` followed by `window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));`.

This change ensures that the navigation to `/dashboard` is handled by the client-side router (`Router.tsx`). This prevents the unnecessary request to the server and the 404 error that followed. The application's existing loading state (`DashboardLoader` driven by `useAuth`) will manage the UI during the transition until your session information is fully processed and the dashboard can be displayed.

This directly addresses the problem where you would see a 404 page after logging in with email, and had to manually edit the URL and reload to get to the dashboard.