### PR TITLE
Fix: Prevent potential 'Invalid hook call' error from debugLog

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -36,8 +36,6 @@ export const useAuth = () => {
   const debugLog = (step: string, data?: any, error?: any) => {
     const timestamp = new Date().toISOString();
     console.log(`[AUTH DEBUG ${timestamp}] ${step}:`, { data, error, tabVisible: isTabVisible.current });
-    
-    setState(prev => ({ ...prev, authStep: step }));
   };
 
   // Show error toast only once per session


### PR DESCRIPTION
Removes the `setState` call from the `debugLog` function within the `useAuth` hook (`src/hooks/useAuth.ts`).

The `debugLog` function was previously updating the `authStep` piece of state. If `debugLog` was called from certain asynchronous contexts (e.g., deep within promise chains related to image transfer or other async operations), the `setState` call could potentially occur when React's context for state updates was no longer valid, leading to an "Invalid hook call" error.

This change simplifies `debugLog` to be a console-logging utility only. While this reduces the granularity of the `authStep` state variable for debugging purposes, it makes the `debugLog` function safer and aims to resolve the critical runtime error. Core authentication state updates (user, loading, error, and critical authSteps for UI like 'fetching_profile') are handled by separate, direct `setState` calls within the `useAuth` hook and remain unaffected.